### PR TITLE
fix(search): Search is now case insensitive with wildcard support

### DIFF
--- a/src/main/java/io/apicollab/server/domain/Api.java
+++ b/src/main/java/io/apicollab/server/domain/Api.java
@@ -3,11 +3,11 @@ package io.apicollab.server.domain;
 import io.apicollab.server.constant.ApiStatus;
 import io.apicollab.server.mapper.ApiTagsConverter;
 import lombok.*;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
-import org.hibernate.search.annotations.Field;
-import org.hibernate.search.annotations.FieldBridge;
-import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.*;
 import org.hibernate.search.bridge.builtin.EnumBridge;
 
 import javax.persistence.*;
@@ -21,6 +21,12 @@ import java.util.List;
 @EqualsAndHashCode(of = {"id"})
 @ToString(of = {"id", "name"})
 @Indexed
+@AnalyzerDef(name = "lowercaseAnalyser",
+        tokenizer = @TokenizerDef(factory = StandardTokenizerFactory.class),
+        filters = {
+                @TokenFilterDef(factory = LowerCaseFilterFactory.class),
+        }
+)
 public class Api extends BaseEntity {
 
     private static final long serialVersionUID = 8281554038825109184L;
@@ -53,6 +59,7 @@ public class Api extends BaseEntity {
     @Lob
     @Type(type="org.hibernate.type.StringType")
     @Field()
+    @Analyzer(definition = "lowercaseAnalyser")
     private String swaggerDefinition;
 
     @ManyToOne

--- a/src/main/java/io/apicollab/server/repository/ApiSearchRepository.java
+++ b/src/main/java/io/apicollab/server/repository/ApiSearchRepository.java
@@ -22,6 +22,14 @@ public class ApiSearchRepository {
     private EntityManager entityManager;
 
     public List<Api> search(String searchString, List<ApiStatus> statusCodes) {
+
+        // lowercase the search terms
+        searchString = searchString.toLowerCase();
+
+        // prefix the wild card in for each word
+        searchString = searchString.replaceAll("(\\w)\\s", "$1* ").replaceAll("(\\w)$", "$1*");
+
+
         FullTextEntityManager fullTextEntityManager
                 = Search.getFullTextEntityManager(entityManager);
 

--- a/src/test/java/io/apicollab/server/service/ApiSearchTests.java
+++ b/src/test/java/io/apicollab/server/service/ApiSearchTests.java
@@ -60,6 +60,7 @@ public class ApiSearchTests {
         createApi(app, "Fruits API", "apple fruit, banana are awesome", ApiStatus.BETA);
         createApi(app, "Space API", "technology space time are interesting concepts", ApiStatus.STABLE);
         createApi(app, "Old API", " Old technology space time are interesting concepts", ApiStatus.ARCHIVED);
+        createApi(app, "Tech API", "Ban all Tech!", ApiStatus.STABLE);
 
     }
 
@@ -136,10 +137,10 @@ public class ApiSearchTests {
     public void searchCaseInsensitiveSearchMultiplePartialWord() {
         List<Api> results = apiService.search("baN TECH").stream().collect(Collectors.toList());
         assertThat(results).isNotEmpty();
-        assertThat(results).hasSize(2);
-        assertThat(results.get(0).getName()).isEqualToIgnoringCase("Fruits API");
-        assertThat(results.get(1).getName()).isEqualToIgnoringCase("Space API");
-
+        assertThat(results).hasSize(3);
+        assertThat(results.get(0).getName()).isEqualToIgnoringCase("Tech API"); // contains both words
+        assertThat(results.get(1).getName()).isEqualToIgnoringCase("Fruits API"); // contains ban "bananna"
+        assertThat(results.get(2).getName()).isEqualToIgnoringCase("Space API"); // contains technology
     }
 
 }

--- a/src/test/java/io/apicollab/server/service/ApiSearchTests.java
+++ b/src/test/java/io/apicollab/server/service/ApiSearchTests.java
@@ -58,9 +58,9 @@ public class ApiSearchTests {
         Application app = createApp("testApp1", "test1@gmail.com");
         // Create apis with fake descriptions
         createApi(app, "Fruits API", "apple fruit, banana are awesome", ApiStatus.BETA);
-        createApi(app, "Space API", "technology space time are interesting concepts", ApiStatus.STABLE);
+        createApi(app, "Space API", "technology space time are interesting concepts this", ApiStatus.STABLE);
         createApi(app, "Old API", " Old technology space time are interesting concepts", ApiStatus.ARCHIVED);
-        createApi(app, "Tech API", "Ban all Tech!", ApiStatus.STABLE);
+        createApi(app, "Tech API", "Ban this Tech!", ApiStatus.STABLE);
 
     }
 
@@ -141,6 +141,17 @@ public class ApiSearchTests {
         assertThat(results.get(0).getName()).isEqualToIgnoringCase("Tech API"); // contains both words
         assertThat(results.get(1).getName()).isEqualToIgnoringCase("Fruits API"); // contains ban "bananna"
         assertThat(results.get(2).getName()).isEqualToIgnoringCase("Space API"); // contains technology
+    }
+
+    /**
+     * Ensure Search phrase is respected
+     */
+    @Test
+    public void searchPhrase() {
+        List<Api> results = apiService.search("\"ban this tech\"").stream().collect(Collectors.toList());
+        assertThat(results).isNotEmpty();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getName()).isEqualToIgnoringCase("Tech API");
     }
 
 }

--- a/src/test/java/io/apicollab/server/service/ApiSearchTests.java
+++ b/src/test/java/io/apicollab/server/service/ApiSearchTests.java
@@ -107,4 +107,39 @@ public class ApiSearchTests {
         assertThat(results.get(0).getName()).isEqualToIgnoringCase("Space API");
     }
 
+    /**
+     * Case insensitive search
+     */
+    @Test
+    public void searchCaseInsensitiveSearch() {
+        List<Api> results = apiService.search("INTERESTING").stream().collect(Collectors.toList());
+        assertThat(results).isNotEmpty();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getName()).isEqualToIgnoringCase("Space API");
+    }
+
+    /**
+     * Case insensitive search with partial word
+     */
+    @Test
+    public void searchCaseInsensitiveSearchPartialWord() {
+        List<Api> results = apiService.search("INTEREST").stream().collect(Collectors.toList());
+        assertThat(results).isNotEmpty();
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getName()).isEqualToIgnoringCase("Space API");
+    }
+
+    /**
+     * Case insensitive search with partial word
+     */
+    @Test
+    public void searchCaseInsensitiveSearchMultiplePartialWord() {
+        List<Api> results = apiService.search("baN TECH").stream().collect(Collectors.toList());
+        assertThat(results).isNotEmpty();
+        assertThat(results).hasSize(2);
+        assertThat(results.get(0).getName()).isEqualToIgnoringCase("Fruits API");
+        assertThat(results.get(1).getName()).isEqualToIgnoringCase("Space API");
+
+    }
+
 }


### PR DESCRIPTION
This PR addresses issue #61....
The solution involves
- Hibernate Search converting input words to lowercase
- Search terms are converted to lowercase
- Each search term has the * wildcard character appended. 